### PR TITLE
Fix shell wrapper recursion and disable colors in non-TTY output

### DIFF
--- a/bin/cconfig.js
+++ b/bin/cconfig.js
@@ -13,6 +13,14 @@ const path = require('path');
 const os = require('os');
 const Table = require('cli-table3');
 
+// Disable chalk colors when stdout is not a TTY unless explicitly overridden
+if (
+  !process.stdout.isTTY &&
+  process.env.CCONFIG_ALLOW_COLOR_IN_PIPES !== '1'
+) {
+  chalk.level = 0;
+}
+
 // Import package.json for version
 const packageJson = require('../package.json');
 


### PR DESCRIPTION
## Summary
- rewrite `cconfig.sh` helpers to execute the local repo CLI when available or fall back to the globally installed binary without recursion, and refactor the Claude helper to capture env exports safely
- ensure the CLI disables chalk colors when stdout is piped unless explicitly overridden to keep scripted output and tests stable

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c392a1c71c832683aa1741ac7f0808